### PR TITLE
feat(rider): 骑手历史订单 + 用户配送进度感知 + 骑手卡片增强(地址/菜品摘要)

### DIFF
--- a/docs/PR3-开发建议.md
+++ b/docs/PR3-开发建议.md
@@ -1,0 +1,139 @@
+# PR3 开发建议（骑手端收尾 + 用户侧配送感知）
+
+本文基于 PR2（骑手订单履约核心）合并后的现状，梳理 PR3 的开发范围、已知 Bug、新功能建议及 Git 操作流程。
+
+---
+
+## 一、PR2 遗留 Bug（已在 develop 上修复）
+
+以下两处 Bug 已直接在 `develop` 分支修复，PR3 分支从 `develop` 切出后自动包含：
+
+| 文件 | 问题 | 修复内容 |
+|------|------|---------|
+| `frontend/src/views/rider/RiderHomeView.vue` | `statusText(3)` 返回 "已到店"，但 status=3 实际是骑手已到店并进入配送阶段 | 改为 **"配送中"** |
+| `frontend/src/views/rider/RiderHomeView.vue` | "到店" 按钮只判断 `order.status === 2`，若 `riderArriveShop` 不改变 status 则按钮永远不消失 | 增加 `&& !order.riderArriveShopTime` 条件 |
+
+---
+
+## 二、PR3 建议开发范围
+
+### 2.1 骑手端——历史订单
+
+**目标**：骑手可查看已完成（status=4）的历史配送记录。
+
+后端：
+- `GET /api/rider/orders/history?page=1&pageSize=20`
+- `OrderService` 新增 `riderHistoryOrders(String authorization, int page, int pageSize)`
+- `OrderMapper` 新增查询：`WHERE rider_id = #{riderId} AND status = 4 ORDER BY rider_delivered_time DESC`
+
+前端：
+- `RiderHomeView.vue` 新增第三个 Tab "历史记录"
+- 展示：订单号、金额、送达时间
+
+---
+
+### 2.2 用户端——订单配送状态感知
+
+**目标**：用户在 `UserOrdersView.vue` 中能看到订单当前配送进度。
+
+前端（无需新接口，利用现有 `GET /api/user/orders`）：
+- 当 `order.status === 2`：显示 "骑手已接单，正在前往商家"
+- 当 `order.status === 3 && !order.riderPickupTime`：显示 "骑手已到店，等待取餐"
+- 当 `order.status === 3 && order.riderPickupTime`：显示 "配送中"
+- 当 `order.status === 4`：显示 "已送达 ✓"
+
+后端（可选增强）：
+- 在用户订单详情中返回 `riderArriveShopTime`、`riderPickupTime`、`riderDeliveredTime` 字段（检查现有 DTO 是否已包含）
+
+---
+
+### 2.3 骑手端——订单卡片信息增强
+
+**目标**：订单卡片显示更多有用信息，减少骑手操作失误。
+
+当前卡片只显示：订单号、金额、店铺ID。
+
+建议增加：
+- 收货地址（`shippingAddress`）
+- 下单时间（`createTime`）
+- 菜品摘要（可选，需后端 DTO 支持）
+
+后端：检查 `riderDispatchOrders` / `riderCurrentOrders` 返回的 DTO 是否包含 `shippingAddress`，若无则在 `OrderMapper.xml` 对应查询中补充字段。
+
+---
+
+### 2.4 测试补充
+
+| 测试类 | 建议覆盖场景 |
+|--------|------------|
+| `RiderOrderFulfillmentTest`（新建） | accept → arriveShop → pickup → delivered 完整流程；重复操作幂等性；非本人骑手操作返回 403 |
+| `RiderOrderControllerTest`（新建） | 各接口 HTTP 状态码；未登录返回 401；骑手 Token 调用用户接口返回 403 |
+
+---
+
+### 2.5 接口文档更新
+
+在 `docs/backend-api.md` 补充：
+
+```
+### 骑手订单历史
+GET /api/rider/orders/history
+Authorization: Bearer <rider_token>
+Query: page, pageSize
+Response: { records: [...], total, page, pageSize }
+```
+
+---
+
+## 三、骑手订单状态流转总结（PR2 实现，PR3 参考）
+
+```
+用户下单 → status=0（待支付）
+用户支付 → status=1（已支付/待接单）
+骑手接单 → status=2（已接单）  riderAcceptTime ✓
+骑手到店 → status=3（配送中）  riderArriveShopTime ✓
+骑手取餐 →                     riderPickupTime ✓（status 仍为 3）
+骑手送达 → status=4（已完成）  riderDeliveredTime ✓
+```
+
+> **注意**：`riderArriveShop` 将 status 从 2 改为 3；`riderPickup` 只记录时间不改 status；`riderDelivered` 将 status 从 3 改为 4。
+
+---
+
+## 四、PR3 Git 操作流程
+
+```bash
+# 1. 从最新 develop 切出功能分支
+git checkout develop
+git pull origin develop
+git checkout -b feature/rider-PR3-history-ux
+
+# 2. 开发、提交
+git add .
+git commit -m "feat(rider): PR3 历史订单 + 用户配送感知 + 测试"
+
+# 3. 推送并创建 PR
+git push origin feature/rider-PR3-history-ux
+gh pr create --base develop --title "Feature/rider PR3 history ux" --body "骑手历史订单、用户配送状态感知、测试补充"
+
+# 4. 合并前跑测试
+./mvnw test
+
+# 5. 合并后同步本地
+git checkout develop && git pull origin develop
+```
+
+---
+
+## 五、PR3 自查清单
+
+| 项目 | 检查点 |
+|------|--------|
+| 后端 | `riderHistoryOrders` 接口已实现并注册到 Controller |
+| 后端 | 用户订单 DTO 包含 `riderArriveShopTime` / `riderPickupTime` |
+| 前端 | 骑手端 "历史记录" Tab 正常展示 |
+| 前端 | 用户订单列表配送进度文案正确 |
+| 测试 | `./mvnw test` 全部通过 |
+| 文档 | `docs/backend-api.md` 已补充历史订单接口 |
+| Git | PR base 分支为 **`develop`** 而非 `master` |
+| Git | 合并后本地已 `git pull` |

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -623,7 +623,39 @@ JWT 身份类型（`type`）：
 
 - `PATCH /api/rider/orders/{orderId}/delivered`
 
-### 9.10 骑手位置上报（可选增强）
+### 9.10 骑手历史订单
+
+- `GET /api/rider/orders/history?page=1&pageSize=20`
+- `Authorization: Bearer <rider_token>`
+
+说明：返回该骑手已完成（status=4）的历史配送记录，按送达时间倒序。
+
+返回:
+
+```json
+{
+  "code": 200,
+  "msg": "success",
+  "data": {
+    "records": [
+      {
+        "id": 1001,
+        "orderNo": "YSH202604010001",
+        "totalAmount": 36.00,
+        "shippingAddress": "XX大学3号楼",
+        "dishSummary": "黑椒鸡排饭、可乐",
+        "riderDeliveredTime": "2026-04-01 14:30:00",
+        "createTime": "2026-04-01 13:00:00"
+      }
+    ],
+    "total": 15,
+    "page": 1,
+    "pageSize": 20
+  }
+}
+```
+
+### 9.11 骑手位置上报（可选增强）
 
 - `POST /api/rider/location/report`
 

--- a/frontend/src/api/rider.js
+++ b/frontend/src/api/rider.js
@@ -48,3 +48,10 @@ export function riderDelivered(token, orderId) {
     headers: { Authorization: `Bearer ${token}` },
   })
 }
+
+export function fetchHistoryOrders(token, params = {}) {
+  return request.get('/rider/orders/history', {
+    params,
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}

--- a/frontend/src/views/rider/RiderHomeView.vue
+++ b/frontend/src/views/rider/RiderHomeView.vue
@@ -16,8 +16,9 @@
 
     <section class="panel">
       <div class="tabs">
-        <button :class="{ active: tab === 'dispatch' }" @click="tab = 'dispatch'">可接订单</button>
-        <button :class="{ active: tab === 'current' }" @click="tab = 'current'">我的进行中</button>
+        <button :class="{ active: tab === 'dispatch' }" @click="switchTab('dispatch')">可接订单</button>
+        <button :class="{ active: tab === 'current' }" @click="switchTab('current')">我的进行中</button>
+        <button :class="{ active: tab === 'history' }" @click="switchTab('history')">历史记录</button>
       </div>
 
       <div v-if="loading" class="tip">加载中...</div>
@@ -29,16 +30,23 @@
             <span>{{ statusText(order.status) }}</span>
           </div>
           <p>金额：¥{{ formatMoney(order.totalAmount) }}</p>
-          <p>店铺ID：{{ order.shopId }}</p>
-          <div class="actions">
+          <p v-if="order.shippingAddress" class="info-line">📍 {{ order.shippingAddress }}</p>
+          <p v-if="order.createTime" class="info-line">下单：{{ order.createTime }}</p>
+          <p v-if="order.dishSummary" class="info-line dish-summary">{{ order.dishSummary }}</p>
+          <p v-if="tab === 'history' && order.riderDeliveredTime" class="info-line">送达：{{ order.riderDeliveredTime }}</p>
+          <div v-if="tab !== 'history'" class="actions">
             <button v-if="tab === 'dispatch'" class="btn primary" @click="accept(order.id)">接单</button>
             <template v-else>
-              <button v-if="order.status === 2" class="btn" @click="arrive(order.id)">到店</button>
+              <button v-if="order.status === 2 && !order.riderArriveShopTime" class="btn" @click="arrive(order.id)">到店</button>
               <button v-if="order.status === 3 && !order.riderPickupTime" class="btn" @click="pickup(order.id)">取餐</button>
               <button v-if="order.status === 3 && order.riderPickupTime" class="btn success" @click="delivered(order.id)">送达</button>
             </template>
           </div>
         </article>
+      </div>
+
+      <div v-if="tab === 'history' && historyTotal > historyOrders.length" class="load-more">
+        <button class="btn" @click="loadMoreHistory" :disabled="loading">加载更多</button>
       </div>
     </section>
   </div>
@@ -51,6 +59,7 @@ import { useAuthStore } from '@/stores/auth'
 import {
   fetchCurrentOrders,
   fetchDispatchOrders,
+  fetchHistoryOrders,
   riderAcceptOrder,
   riderArriveShop,
   riderDelivered,
@@ -65,9 +74,16 @@ const tab = ref('dispatch')
 const loading = ref(false)
 const dispatchOrders = ref([])
 const currentOrders = ref([])
+const historyOrders = ref([])
+const historyPage = ref(1)
+const historyTotal = ref(0)
 const workStatus = ref(auth.riderProfile?.workStatus || 'ONLINE')
 
-const activeList = computed(() => (tab.value === 'dispatch' ? dispatchOrders.value : currentOrders.value))
+const activeList = computed(() => {
+  if (tab.value === 'dispatch') return dispatchOrders.value
+  if (tab.value === 'current') return currentOrders.value
+  return historyOrders.value
+})
 
 onMounted(async () => {
   await syncRiderProfile()
@@ -97,6 +113,36 @@ async function loadData() {
     console.error('加载骑手订单失败', e)
   } finally {
     loading.value = false
+  }
+}
+
+async function loadHistory(page = 1) {
+  loading.value = true
+  try {
+    const res = await fetchHistoryOrders(auth.riderToken, { page, pageSize: 20 })
+    const data = res.data.data || {}
+    if (page === 1) {
+      historyOrders.value = data.records || []
+    } else {
+      historyOrders.value = [...historyOrders.value, ...(data.records || [])]
+    }
+    historyTotal.value = data.total || 0
+    historyPage.value = page
+  } catch (e) {
+    console.error('加载历史订单失败', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMoreHistory() {
+  await loadHistory(historyPage.value + 1)
+}
+
+function switchTab(newTab) {
+  tab.value = newTab
+  if (newTab === 'history' && historyOrders.value.length === 0) {
+    loadHistory(1)
   }
 }
 
@@ -160,7 +206,7 @@ function statusText(status) {
   return {
     1: '待接单',
     2: '已接单',
-    3: '已到店',
+    3: '配送中',
     4: '已送达',
   }[status] || `状态${status}`
 }
@@ -185,8 +231,11 @@ function formatMoney(v) {
 .card { border: 1px solid #e2e8f0; border-radius: 10px; padding: 10px; }
 .head { display: flex; justify-content: space-between; align-items: center; }
 .head p { margin: 0; font-weight: 600; }
+.info-line { margin: 4px 0 0; color: #64748b; font-size: 13px; }
+.dish-summary { color: #475569; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 .actions { display: flex; gap: 8px; margin-top: 6px; }
 .btn.primary { background: #2563eb; color: #fff; border-color: #2563eb; }
 .btn.success { background: #16a34a; color: #fff; border-color: #16a34a; }
 .tip { color: #64748b; }
+.load-more { text-align: center; margin-top: 12px; }
 </style>

--- a/frontend/src/views/user/UserOrdersView.vue
+++ b/frontend/src/views/user/UserOrdersView.vue
@@ -21,6 +21,10 @@
           </div>
         </header>
 
+        <div v-if="deliveryProgress(order)" class="delivery-progress">
+          {{ deliveryProgress(order) }}
+        </div>
+
         <div class="card-body">
           <p>金额：<b>¥{{ formatMoney(order.totalAmount) }}</b></p>
           <p v-if="order.remark">备注：{{ order.remark }}</p>
@@ -210,6 +214,14 @@ function payStatusText(status) {
   }[status] || '未知'
 }
 
+function deliveryProgress(order) {
+  if (order.status === 2) return '🚴 骑手已接单，正在前往商家'
+  if (order.status === 3 && !order.riderPickupTime) return '🏪 骑手已到店，等待取餐'
+  if (order.status === 3 && order.riderPickupTime) return '🛵 配送中'
+  if (order.status === 4) return '✅ 已送达'
+  return ''
+}
+
 function formatMoney(v) {
   const n = Number(v || 0)
   return n.toFixed(2)
@@ -310,6 +322,15 @@ function formatMoney(v) {
   grid-template-columns: 1fr auto auto;
   gap: 12px;
   padding: 6px 0;
+}
+.delivery-progress {
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: #f0fdf4;
+  border-radius: 6px;
+  color: #15803d;
+  font-size: 13px;
+  font-weight: 500;
 }
 .tip { color: #888; }
 </style>

--- a/src/main/java/com/example/springbootblank/order/controller/RiderOrderController.java
+++ b/src/main/java/com/example/springbootblank/order/controller/RiderOrderController.java
@@ -73,4 +73,13 @@ public class RiderOrderController {
         orderService.riderDelivered(authorization, orderId);
         return ApiResponse.ok();
     }
+
+    @GetMapping("/history")
+    public ApiResponse<Map<String, Object>> history(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize
+    ) {
+        return ApiResponse.ok(orderService.riderHistoryOrders(authorization, page, pageSize));
+    }
 }

--- a/src/main/java/com/example/springbootblank/order/entity/Order.java
+++ b/src/main/java/com/example/springbootblank/order/entity/Order.java
@@ -22,6 +22,8 @@ public class Order {
     private LocalDateTime cancelTime;
     private LocalDateTime createTime;
     private LocalDateTime updateTime;
+    private String shippingAddress;
+    private String dishSummary;
 
     public Long getId() {
         return id;
@@ -165,5 +167,21 @@ public class Order {
 
     public void setUpdateTime(LocalDateTime updateTime) {
         this.updateTime = updateTime;
+    }
+
+    public String getShippingAddress() {
+        return shippingAddress;
+    }
+
+    public void setShippingAddress(String shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
+
+    public String getDishSummary() {
+        return dishSummary;
+    }
+
+    public void setDishSummary(String dishSummary) {
+        this.dishSummary = dishSummary;
     }
 }

--- a/src/main/java/com/example/springbootblank/order/mapper/OrderMapper.java
+++ b/src/main/java/com/example/springbootblank/order/mapper/OrderMapper.java
@@ -71,4 +71,10 @@ public interface OrderMapper {
     int riderPickup(@Param("orderId") Long orderId, @Param("riderId") Long riderId);
 
     int riderDelivered(@Param("orderId") Long orderId, @Param("riderId") Long riderId);
+
+    long countRiderHistoryOrders(@Param("riderId") Long riderId);
+
+    List<Order> listRiderHistoryOrders(@Param("riderId") Long riderId,
+                                       @Param("offset") int offset,
+                                       @Param("pageSize") int pageSize);
 }

--- a/src/main/java/com/example/springbootblank/order/service/OrderService.java
+++ b/src/main/java/com/example/springbootblank/order/service/OrderService.java
@@ -35,4 +35,6 @@ public interface OrderService {
     void riderPickup(String authorization, Long orderId);
 
     void riderDelivered(String authorization, Long orderId);
+
+    Map<String, Object> riderHistoryOrders(String authorization, int page, int pageSize);
 }

--- a/src/main/java/com/example/springbootblank/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/example/springbootblank/order/service/OrderServiceImpl.java
@@ -290,6 +290,22 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 
+    @Override
+    public Map<String, Object> riderHistoryOrders(String authorization, int page, int pageSize) {
+        Long riderId = resolveRiderId(authorization);
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.max(pageSize, 1);
+        int offset = (safePage - 1) * safeSize;
+        long total = orderMapper.countRiderHistoryOrders(riderId);
+        List<Order> records = orderMapper.listRiderHistoryOrders(riderId, offset, safeSize);
+        return Map.of(
+                "page", safePage,
+                "pageSize", safeSize,
+                "total", total,
+                "records", records
+        );
+    }
+
     private void applyMerchantStatusTransition(
             Long orderId,
             int fromStatus,

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -31,6 +31,11 @@
                remark,
                status,
                pay_status AS payStatus,
+               rider_id AS riderId,
+               rider_accept_time AS riderAcceptTime,
+               rider_arrive_shop_time AS riderArriveShopTime,
+               rider_pickup_time AS riderPickupTime,
+               rider_delivered_time AS riderDeliveredTime,
                pay_time AS payTime,
                finish_time AS finishTime,
                cancel_time AS cancelTime,
@@ -54,6 +59,11 @@
                remark,
                status,
                pay_status AS payStatus,
+               rider_id AS riderId,
+               rider_accept_time AS riderAcceptTime,
+               rider_arrive_shop_time AS riderArriveShopTime,
+               rider_pickup_time AS riderPickupTime,
+               rider_delivered_time AS riderDeliveredTime,
                pay_time AS payTime,
                finish_time AS finishTime,
                cancel_time AS cancelTime,
@@ -204,28 +214,32 @@
     </select>
 
     <select id="listDispatchOrders" resultType="com.example.springbootblank.order.entity.Order">
-        SELECT id,
-               order_no AS orderNo,
-               user_id AS userId,
-               shop_id AS shopId,
-               total_amount AS totalAmount,
-               remark,
-               status,
-               pay_status AS payStatus,
-               rider_id AS riderId,
-               rider_accept_time AS riderAcceptTime,
-               rider_arrive_shop_time AS riderArriveShopTime,
-               rider_pickup_time AS riderPickupTime,
-               rider_delivered_time AS riderDeliveredTime,
-               pay_time AS payTime,
-               finish_time AS finishTime,
-               cancel_time AS cancelTime,
-               create_time AS createTime,
-               update_time AS updateTime
-        FROM orders
-        WHERE status = 1
-          AND rider_id IS NULL
-        ORDER BY id ASC
+        SELECT o.id,
+               o.order_no AS orderNo,
+               o.user_id AS userId,
+               o.shop_id AS shopId,
+               o.total_amount AS totalAmount,
+               o.remark,
+               o.status,
+               o.pay_status AS payStatus,
+               o.rider_id AS riderId,
+               o.rider_accept_time AS riderAcceptTime,
+               o.rider_arrive_shop_time AS riderArriveShopTime,
+               o.rider_pickup_time AS riderPickupTime,
+               o.rider_delivered_time AS riderDeliveredTime,
+               o.pay_time AS payTime,
+               o.finish_time AS finishTime,
+               o.cancel_time AS cancelTime,
+               o.create_time AS createTime,
+               o.update_time AS updateTime,
+               u.shipping_address AS shippingAddress,
+               (SELECT GROUP_CONCAT(oi.dish_name SEPARATOR '、')
+                FROM order_item oi WHERE oi.order_id = o.id) AS dishSummary
+        FROM orders o
+        LEFT JOIN user u ON u.id = o.user_id
+        WHERE o.status = 1
+          AND o.rider_id IS NULL
+        ORDER BY o.id ASC
         LIMIT #{pageSize} OFFSET #{offset}
     </select>
 
@@ -240,28 +254,32 @@
     </update>
 
     <select id="listRiderCurrentOrders" resultType="com.example.springbootblank.order.entity.Order">
-        SELECT id,
-               order_no AS orderNo,
-               user_id AS userId,
-               shop_id AS shopId,
-               total_amount AS totalAmount,
-               remark,
-               status,
-               pay_status AS payStatus,
-               rider_id AS riderId,
-               rider_accept_time AS riderAcceptTime,
-               rider_arrive_shop_time AS riderArriveShopTime,
-               rider_pickup_time AS riderPickupTime,
-               rider_delivered_time AS riderDeliveredTime,
-               pay_time AS payTime,
-               finish_time AS finishTime,
-               cancel_time AS cancelTime,
-               create_time AS createTime,
-               update_time AS updateTime
-        FROM orders
-        WHERE rider_id = #{riderId}
-          AND status IN (2, 3, 4)
-        ORDER BY id DESC
+        SELECT o.id,
+               o.order_no AS orderNo,
+               o.user_id AS userId,
+               o.shop_id AS shopId,
+               o.total_amount AS totalAmount,
+               o.remark,
+               o.status,
+               o.pay_status AS payStatus,
+               o.rider_id AS riderId,
+               o.rider_accept_time AS riderAcceptTime,
+               o.rider_arrive_shop_time AS riderArriveShopTime,
+               o.rider_pickup_time AS riderPickupTime,
+               o.rider_delivered_time AS riderDeliveredTime,
+               o.pay_time AS payTime,
+               o.finish_time AS finishTime,
+               o.cancel_time AS cancelTime,
+               o.create_time AS createTime,
+               o.update_time AS updateTime,
+               u.shipping_address AS shippingAddress,
+               (SELECT GROUP_CONCAT(oi.dish_name SEPARATOR '、')
+                FROM order_item oi WHERE oi.order_id = o.id) AS dishSummary
+        FROM orders o
+        LEFT JOIN user u ON u.id = o.user_id
+        WHERE o.rider_id = #{riderId}
+          AND o.status IN (2, 3, 4)
+        ORDER BY o.id DESC
     </select>
 
     <update id="riderArriveShop">
@@ -293,5 +311,42 @@
           AND status = 3
           AND rider_pickup_time IS NOT NULL
     </update>
+
+    <select id="countRiderHistoryOrders" resultType="long">
+        SELECT COUNT(*)
+        FROM orders
+        WHERE rider_id = #{riderId}
+          AND status = 4
+    </select>
+
+    <select id="listRiderHistoryOrders" resultType="com.example.springbootblank.order.entity.Order">
+        SELECT o.id,
+               o.order_no AS orderNo,
+               o.user_id AS userId,
+               o.shop_id AS shopId,
+               o.total_amount AS totalAmount,
+               o.remark,
+               o.status,
+               o.pay_status AS payStatus,
+               o.rider_id AS riderId,
+               o.rider_accept_time AS riderAcceptTime,
+               o.rider_arrive_shop_time AS riderArriveShopTime,
+               o.rider_pickup_time AS riderPickupTime,
+               o.rider_delivered_time AS riderDeliveredTime,
+               o.pay_time AS payTime,
+               o.finish_time AS finishTime,
+               o.cancel_time AS cancelTime,
+               o.create_time AS createTime,
+               o.update_time AS updateTime,
+               u.shipping_address AS shippingAddress,
+               (SELECT GROUP_CONCAT(oi.dish_name SEPARATOR '、')
+                FROM order_item oi WHERE oi.order_id = o.id) AS dishSummary
+        FROM orders o
+        LEFT JOIN user u ON u.id = o.user_id
+        WHERE o.rider_id = #{riderId}
+          AND o.status = 4
+        ORDER BY o.rider_delivered_time DESC
+        LIMIT #{pageSize} OFFSET #{offset}
+    </select>
 
 </mapper>


### PR DESCRIPTION
新增骑手历史订单接口（GET /api/rider/orders/history），支持分页查询已完成配送记录
用户订单列表新增配送进度感知，根据骑手履约状态实时显示「骑手已接单」「骑手已到店」「配送中」「已送达」
骑手订单卡片信息增强：通过 JOIN user 表展示收货地址，子查询聚合菜品摘要，同时显示下单时间
用户订单查询（listUserOrders / findUserOrderById）补充 rider 时间字段，支撑前端配送状态展示
补充 backend-api.md 骑手历史订单接口文档